### PR TITLE
Use non-expiring token for reindex-all operation, add timestamp to ES docs

### DIFF
--- a/src/routes/file_info/file_info_blueprint.py
+++ b/src/routes/file_info/file_info_blueprint.py
@@ -54,7 +54,7 @@ def construct_blueprint(appConfig):
             fworker = FileWorker(appConfig=app_config, requestHeaders=request.headers)
 
             # Verify the user is a Data Admin, who can view file document constructs outside Elasticsearch
-            if not fworker.verify_data_admin():
+            if not fworker.verify_user_is_data_admin():
                 # Should never be reached, if AWS Gateway configured per comment by @file_info_blueprint.route()
                 raise Exception("Permission denied for requested operation.")
 

--- a/src/routes/file_info_index/file_info_index_blueprint.py
+++ b/src/routes/file_info_index/file_info_index_blueprint.py
@@ -29,7 +29,7 @@ def construct_blueprint(appConfig):
             # Specify argument to confirm dataset_id is for a Dataset entity.
             theDataset = fworker.get_entity(entity_id=dataset_id, entity_type_check='DATASET')
 
-            if not fworker.verify_user_in_write_group(aDataset=theDataset) and not fworker.verify_data_admin():
+            if not fworker.verify_user_in_write_group(aDataset=theDataset) and not fworker.verify_user_is_data_admin():
                 raise Exception(f"Permission denied for modifying ES index entries for '{theDataset['uuid']}'.")
 
             dataset_uuid = theDataset['uuid']
@@ -90,7 +90,7 @@ def construct_blueprint(appConfig):
         fworker = FileWorker(appConfig=app_config, requestHeaders=request.headers)
 
         # Verify the user is a Data Admin, who can index all datasets
-        if not fworker.verify_data_admin():
+        if not fworker.verify_user_is_data_admin():
             raise Exception("Permission denied for requested operation.")
 
         asynchronous = request.args.get('async')


### PR DESCRIPTION
Use non-expiring token for reindex-all operation. Refactoring of methods and logging. Added UTC timestamp to Elasticsearch documents to support incremental updates.